### PR TITLE
Try number 2.

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: Install packages
       run: |
+        export DISPLAY=:99
         pip install --upgrade pip wheel setuptools
         pip install -r requirements.txt
         pip install -r requirements/extra.txt


### PR DESCRIPTION
Add `export` to both `run` commands, assuming environment is not preserved between each